### PR TITLE
Add namespace field to logs

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -12,12 +12,14 @@ pub struct Log {
     pub log_type: String,
     log_text: String,
     ts_rfc3339: String,
+    namespace: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct UnstructuredLogs {
     customer_id: String,
     pub log_type: String,
+    namespace: Option<String>,
     entries: Vec<UnstructuredLog>,
 }
 
@@ -43,6 +45,7 @@ impl From<UnstructuredLogs> for Vec<Log> {
                         .unwrap_or_else(Utc::now)
                         .to_rfc3339()
                 }),
+                namespace: logs.namespace.clone()
             })
             .collect()
     }


### PR DESCRIPTION
A recent [PR](https://github.com/vectordotdev/vector/pull/19398) has added the namespace field to Chronicle. This updates the emulator so that it tracks the namespace field sent to it so the integration tests pass. 